### PR TITLE
Add Ruby version 3.3 to testing matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         ruby:
           - '3.2.2'
+          - '3.3'
 
     steps:
     - uses: actions/checkout@v3

--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,3 @@ gemspec
 gem "rake", "~> 13.0"
 
 gem "rspec", "~> 3.0"
-
-gem "standard", "~> 1.3"

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,4 @@ require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
-require "standard/rake"
-
-task default: %i[spec standard]
+task default: %i[spec]


### PR DESCRIPTION
It's always good to test against the most recent release of Ruby 💎 
[3.3.0 was released on 2023-12-25](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/)

Maybe we could also change the 3.2.2 version specification in the matrix to 3.2 since Ruby does a good job of releasing a patch version without creating breaking changes?